### PR TITLE
Get rid of experimental features

### DIFF
--- a/examples/regfs/main.rs
+++ b/examples/regfs/main.rs
@@ -1,4 +1,3 @@
-#![feature(try_trait, slice_concat_trait)]
 use anyhow::Result;
 use prjfs::provider::{Provider, ProviderT};
 use prjfs::{NotificationType, OptionBuilder};

--- a/src/guid.rs
+++ b/src/guid.rs
@@ -1,3 +1,4 @@
+use anyhow::{Result, bail};
 use winapi::shared::guiddef::GUID;
 use winapi::um::combaseapi::CoCreateGuid;
 
@@ -7,21 +8,24 @@ pub fn create_guid() -> GUID {
     guid
 }
 
-pub fn guid_from_bytes(bytes: Vec<u8>) -> std::result::Result<GUID, std::option::NoneError> {
+pub fn guid_from_bytes(bytes: Vec<u8>) -> Result<GUID> {
+    if bytes.len() < 16 {
+        bail!("Not enough bytes for converting into a GUID");
+    }
     let mut guid = bytes.into_iter();
     Ok(GUID {
-        Data1: u32::from_be_bytes([guid.next()?, guid.next()?, guid.next()?, guid.next()?]),
-        Data2: u16::from_be_bytes([guid.next()?, guid.next()?]),
-        Data3: u16::from_be_bytes([guid.next()?, guid.next()?]),
+        Data1: u32::from_be_bytes([guid.next().unwrap(), guid.next().unwrap(), guid.next().unwrap(), guid.next().unwrap()]),
+        Data2: u16::from_be_bytes([guid.next().unwrap(), guid.next().unwrap()]),
+        Data3: u16::from_be_bytes([guid.next().unwrap(), guid.next().unwrap()]),
         Data4: [
-            guid.next()?,
-            guid.next()?,
-            guid.next()?,
-            guid.next()?,
-            guid.next()?,
-            guid.next()?,
-            guid.next()?,
-            guid.next()?,
+            guid.next().unwrap(),
+            guid.next().unwrap(),
+            guid.next().unwrap(),
+            guid.next().unwrap(),
+            guid.next().unwrap(),
+            guid.next().unwrap(),
+            guid.next().unwrap(),
+            guid.next().unwrap(),
         ],
     })
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(try_trait)]
-
 pub mod conv;
 pub mod guid;
 pub mod option;

--- a/src/option.rs
+++ b/src/option.rs
@@ -22,7 +22,7 @@ bitflags::bitflags! {
 }
 
 impl NotificationType {
-    fn into_raw(self) -> crate::sys::PRJ_NOTIFY_TYPES {
+    fn into_raw(&self) -> crate::sys::PRJ_NOTIFY_TYPES {
         let mut raw = crate::sys::PRJ_NOTIFY_TYPES::default();
 
         if self.contains(NotificationType::NONE) {


### PR DESCRIPTION
Makes use of `unwrap()`, as `std::option::NoneError` is no longer available since https://github.com/rust-lang/rust/pull/85482 was merged